### PR TITLE
Fix: Internet radio stuttering for 1.20.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ parchment_version=2023.09.03
 
 ## Mod
 mod_id=etched
-mod_version=3.0.4
+mod_version=3.0.5
 mod_name=Etched
 mod_description=A new form of entertainment.
 archives_base_name=etched

--- a/src/main/java/gg/moonflower/etched/api/sound/AbstractOnlineSoundInstance.java
+++ b/src/main/java/gg/moonflower/etched/api/sound/AbstractOnlineSoundInstance.java
@@ -6,6 +6,7 @@ import gg.moonflower.etched.api.sound.source.AudioSource;
 import gg.moonflower.etched.api.sound.stream.MonoWrapper;
 import gg.moonflower.etched.api.sound.stream.RawAudioStream;
 import gg.moonflower.etched.api.util.DownloadProgressListener;
+import gg.moonflower.etched.api.util.LiveAudioInputStream;
 import gg.moonflower.etched.api.util.Mp3InputStream;
 import gg.moonflower.etched.api.util.WaveDataReader;
 import gg.moonflower.etched.client.sound.EmptyAudioStream;
@@ -103,12 +104,15 @@ public class AbstractOnlineSoundInstance extends AbstractSoundInstance {
         return SoundCache.getAudioStream(onlineSound.getURL(), onlineSound.getProgressListener(), onlineSound.getAudioFileType()).thenCompose(AudioSource::openStream).thenApplyAsync(stream -> {
             onlineSound.getProgressListener().progressStartLoading();
             try {
+                // Live audio streams are infinite and must not be wrapped in LoopingAudioStream
+                // (which would attempt to rewind the stream on EOF — EOF never arrives).
+                boolean repeat = repeatInstantly && !(stream instanceof LiveAudioInputStream);
                 InputStream is = new BufferedInputStream(stream);
 
                 // Try loading as OGG
                 try {
                     is.mark(4192);
-                    return getStream(repeatInstantly ? new LoopingAudioStream(OggAudioStream::new, is) : new OggAudioStream(is), sound);
+                    return getStream(repeat ? new LoopingAudioStream(OggAudioStream::new, is) : new OggAudioStream(is), sound);
                 } catch (Exception e) {
                     LOGGER.debug("Failed to load as OGG", e);
                     is.reset();
@@ -118,7 +122,7 @@ public class AbstractOnlineSoundInstance extends AbstractSoundInstance {
                         is.mark(4192);
                         AudioInputStream ais = WaveDataReader.getAudioInputStream(is);
                         AudioFormat format = ais.getFormat();
-                        return getStream(repeatInstantly ? new LoopingAudioStream(input -> new RawAudioStream(format, input), ais) : new RawAudioStream(format, ais), sound);
+                        return getStream(repeat ? new LoopingAudioStream(input -> new RawAudioStream(format, input), ais) : new RawAudioStream(format, ais), sound);
                     } catch (Exception e1) {
                         LOGGER.debug("Failed to load as WAV", e1);
                         is.reset();
@@ -126,7 +130,7 @@ public class AbstractOnlineSoundInstance extends AbstractSoundInstance {
                         // Try loading as MP3
                         try {
                             Mp3InputStream mp3InputStream = new Mp3InputStream(is);
-                            return getStream(repeatInstantly ? new LoopingAudioStream(input -> new RawAudioStream(mp3InputStream.getFormat(), input), mp3InputStream) : new RawAudioStream(mp3InputStream.getFormat(), mp3InputStream), sound);
+                            return getStream(repeat ? new LoopingAudioStream(input -> new RawAudioStream(mp3InputStream.getFormat(), input), mp3InputStream) : new RawAudioStream(mp3InputStream.getFormat(), mp3InputStream), sound);
                         } catch (Exception e2) {
                             LOGGER.debug("Failed to load as MP3", e2);
                             UnsupportedAudioFileException cause = new UnsupportedAudioFileException("Could not load as OGG, WAV, OR MP3");

--- a/src/main/java/gg/moonflower/etched/api/sound/source/AudioSource.java
+++ b/src/main/java/gg/moonflower/etched/api/sound/source/AudioSource.java
@@ -3,6 +3,8 @@ package gg.moonflower.etched.api.sound.source;
 import gg.moonflower.etched.api.sound.download.SoundDownloadSource;
 import gg.moonflower.etched.api.util.AsyncInputStream;
 import gg.moonflower.etched.api.util.DownloadProgressListener;
+import gg.moonflower.etched.api.util.LiveAudioInputStream;
+import gg.moonflower.etched.api.util.ReconnectingInputStream;
 import gg.moonflower.etched.api.util.ProgressTrackingInputStream;
 import gg.moonflower.etched.client.sound.SoundCache;
 import net.minecraft.client.Minecraft;
@@ -13,6 +15,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -45,6 +48,72 @@ public interface AudioSource {
         return map;
     }
 
+
+    /**
+     * Opens a dedicated HTTP connection for live audio streaming.
+     *
+     * A fresh connection is used for each stream (never reused).  The
+     * {@code Accept-Encoding: identity} header prevents SHOUTcast/Icecast
+     * servers from applying compression that would corrupt the raw MP3
+     * byte stream.  Read timeouts are set to 30s — stalled
+     * connections are handled by the {@code ReconnectingInputStream}
+     * wrapper, not by waiting for the timeout.
+     *
+     * The returned stream's {@code close()} method also disconnects
+     * the underlying {@link HttpURLConnection}.
+     */
+    static InputStream openLiveConnection(URL url, Map<String, String> headers) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        headers.forEach(connection::setRequestProperty);
+        connection.setRequestProperty("Accept-Encoding", "identity");
+        connection.setConnectTimeout(10000);
+        connection.setReadTimeout(30000); // A stalled station is reopened by ReconnectingInputStream.
+
+        try {
+            int response = connection.getResponseCode();
+            if (response != HttpURLConnection.HTTP_OK) {
+                throw new IOException("Failed to connect to " + url + ": " + response + ". " + connection.getResponseMessage());
+            }
+
+            InputStream input = connection.getInputStream();
+            return new FilterInputStream(input) {
+                private boolean disconnected;
+
+                @Override
+                public void close() throws IOException {
+                    if (this.disconnected) {
+                        return;
+                    }
+                    this.disconnected = true;
+                    try {
+                        super.close();
+                    } finally {
+                        connection.disconnect();
+                    }
+                }
+            };
+        } catch (Throwable t) {
+            connection.disconnect();
+            if (t instanceof IOException ioException) {
+                throw ioException;
+            }
+            throw new IOException("Failed to open live audio connection", t);
+        }
+    }
+
+    /**
+     * Downloads audio data from a URL.
+     *
+     * For files (content length known): downloads to disk cache with
+     * standard HTTP headers and cache-control handling.
+     *
+     * For live streams (content length unknown or no-cache): the first
+     * connection is used only to classify the URL (status code, headers)
+     * and is disconnected in a finally block.  The actual streaming
+     * connection is opened separately by {@link #openLiveConnection},
+     * wrapped in {@code ReconnectingInputStream} for automatic reconnect
+     * on server disconnect, then buffered through {@code AsyncInputStream}.
+     */
     static AsyncInputStream.InputStreamSupplier downloadTo(URL url, boolean temporary, @Nullable DownloadProgressListener progressListener, AudioFileType type) {
         Path path;
         try {
@@ -62,9 +131,13 @@ public interface AudioSource {
         if (progressListener != null) {
             progressListener.progressStartRequest(Component.translatable("resourcepack.requesting"));
         }
+        HttpURLConnection connection = null;
         try {
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            getDownloadHeaders().forEach(connection::setRequestProperty);
+            // Snapshot headers now — the lambda captures this reference and runs
+            // on a background thread where getDownloadHeaders() may be stale.
+            Map<String, String> requestHeaders = Map.copyOf(getDownloadHeaders());
+            connection = (HttpURLConnection) url.openConnection();
+            requestHeaders.forEach(connection::setRequestProperty);
 
             int response = connection.getResponseCode();
             if (response != 200) {
@@ -151,7 +224,12 @@ public interface AudioSource {
                     if (!type.isStream()) {
                         throw new IOException("The provided URL is a stream, but that is not supported");
                     }
-                    return () -> new AsyncInputStream(url::openStream, 8192, 8, HttpUtil.DOWNLOAD_EXECUTOR);
+                    Map<String, String> liveHeaders = requestHeaders;
+                    return () -> new LiveAudioInputStream(new AsyncInputStream(
+                            () -> new ReconnectingInputStream(() -> openLiveConnection(url, liveHeaders)),
+                            8192,
+                            8,
+                            HttpUtil.DOWNLOAD_EXECUTOR));
                 }
             }
 
@@ -193,6 +271,12 @@ public interface AudioSource {
             }
         } catch (Throwable e) {
             throw new CompletionException(e);
+        } finally {
+            if (connection != null) {
+                // The first request only classifies the URL. Never leave its body open
+                // while a second connection is used for actual live playback.
+                connection.disconnect();
+            }
         }
         return () -> Files.newInputStream(path);
     }

--- a/src/main/java/gg/moonflower/etched/api/util/AsyncInputStream.java
+++ b/src/main/java/gg/moonflower/etched/api/util/AsyncInputStream.java
@@ -2,192 +2,360 @@ package gg.moonflower.etched.api.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.LinkedList;
-import java.util.List;
+import java.io.InterruptedIOException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Asynchronously reads data from one stream into a buffer for another thread to read from.
+ * Asynchronously reads data from a source stream into a bounded in-memory
+ * queue for another thread to consume.
+ *
+ * A background producer thread fetches chunks from the source and appends
+ * them to an internal queue.  The consumer (caller of {@code read()})
+ * blocks on an empty queue until data arrives, the producer reaches real
+ * EOF, or {@link #close()} is called.  Temporary network pauses never
+ * produce a false EOF — the consumer simply waits.
+ *
+ * The producer is protected against busy-looping on stream end and the
+ * consumer receives one internal chunk per {@code read()} call, avoiding
+ * the byte-overwrite bug present in earlier versions.
  *
  * @author Ocelot
  * @since 1.2.0
  */
 public class AsyncInputStream extends InputStream {
 
-    private static final int MAX_DATA = 32768; // A maximum of 32KB can be loaded into memory
+    /** Keep at least this much source data buffered when the requested buffer count is smaller. */
+    private static final int MIN_BUFFERED_DATA = 32768;
 
-    private final List<byte[]> readBytes;
-    private final CompletableFuture<?> readFuture;
-    private final Lock lock;
+    private final Deque<byte[]> readBytes;
+    private final CompletableFuture<Void> initialWait;
+    private final CompletableFuture<Void> readFuture;
+    private final ReentrantLock lock;
+    private final Condition notEmpty;
+    private final Condition notFull;
+    private final int initialBuffers;
     private final int maxBuffers;
+
     private int pointer;
     private byte[] currentData;
     private volatile boolean closed;
-    private CompletableFuture<?> waitFuture;
+    private volatile InputStream sourceStream;
+    private boolean eof;
+    private IOException failure;
 
     public AsyncInputStream(InputStreamSupplier source, int bufferSize, int buffers, Executor readExecutor) throws IOException {
-        this.readBytes = new LinkedList<>();
+        Objects.requireNonNull(source, "source");
+        Objects.requireNonNull(readExecutor, "readExecutor");
+        if (bufferSize <= 0) {
+            throw new IllegalArgumentException("bufferSize must be positive");
+        }
+        if (buffers <= 0) {
+            throw new IllegalArgumentException("buffers must be positive");
+        }
+
+        this.readBytes = new ArrayDeque<>();
+        this.initialWait = new CompletableFuture<>();
         this.lock = new ReentrantLock();
-        this.maxBuffers = Math.max(buffers, MAX_DATA / bufferSize); // At least X buffers, even if it exceeds the data limit
-
-        CompletableFuture<?> initialWait = new CompletableFuture<>();
-        this.waitFuture = CompletableFuture.completedFuture(null); // Nothing to wait for initially
-        this.readFuture = CompletableFuture.runAsync(() -> {
-            try (InputStream stream = source.get()) { // Create stream off-thread to prevent threaded stream issues
-                while (!this.closed) {
-                    byte[] buffer = new byte[bufferSize];
-                    int read, byteCount = 0;
-                    while (!this.closed && byteCount < buffer.length && (read = stream.read(buffer, byteCount, buffer.length - byteCount)) != -1) { // Read from stream until closed
-                        byteCount += read;
-                    }
-
-                    if (!this.closed && byteCount > 0) { // Only append buffers if data is read and not closed
-                        if (byteCount < buffer.length) {
-                            byte[] newBuffer = new byte[byteCount];
-                            System.arraycopy(buffer, 0, newBuffer, 0, newBuffer.length);
-                            this.appendBuffer(newBuffer);
-                        } else {
-                            this.appendBuffer(buffer);
-                        }
-                    }
-
-                    if (!initialWait.isDone() && (this.closed || this.readBytes.size() >= buffers)) { // Complete initial wait if enough is read or buffer is closed
-                        initialWait.complete(null);
-                    }
-                }
-            } catch (IOException e) {
-                if (!initialWait.isDone()) {
-                    initialWait.completeExceptionally(e);
-                }
-                throw new CompletionException(e);
-            }
-        }, readExecutor);
+        this.notEmpty = this.lock.newCondition();
+        this.notFull = this.lock.newCondition();
+        this.initialBuffers = buffers;
+        int minimumBuffers = Math.max(1, (MIN_BUFFERED_DATA + bufferSize - 1) / bufferSize);
+        this.maxBuffers = Math.max(buffers, minimumBuffers);
 
         try {
-            initialWait.join(); // Wait for initial buffers to fill before continuing
+            this.readFuture = CompletableFuture.runAsync(() -> this.readLoop(source, bufferSize), readExecutor);
+        } catch (RuntimeException e) {
+            throw new IOException("Failed to start asynchronous stream reader", e);
+        }
+
+        try {
+            this.initialWait.join(); // Wait for pre-buffering, true EOF, or an opening/read failure.
         } catch (CompletionException e) {
-            if (e.getCause() instanceof IOException) {
-                throw (IOException) e.getCause();
-            } else {
-                throw new IOException(e.getCause());
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException ioException) {
+                throw ioException;
             }
+            throw new IOException(cause);
         }
     }
 
-    private void appendBuffer(byte[] data) {
-        if (this.closed) { // If closed, no point in adding new buffers
-            return;
-        }
-        this.waitFuture.join();
-        if (this.closed) { // close() unlocks this thread after closed has been set
-            return;
-        }
-        try {
-            this.lock.lock();
-            this.readBytes.add(data);
-            if (this.readBytes.size() >= this.maxBuffers) {
-                this.waitFuture = new CompletableFuture<>(); // Enough data has been read, wait until some is read
+    /**
+     * Producer loop running on the background executor.  Reads chunks from the
+     * source stream and appends them to the internal queue.  Exits when the
+     * source reaches EOF, when {@link #closed} is set by {@link #close()},
+     * or when an I/O error occurs.
+     */
+    private void readLoop(InputStreamSupplier source, int bufferSize) {
+        IOException problem = null;
+        try (InputStream stream = Objects.requireNonNull(source.get(), "source returned null")) {
+            this.sourceStream = stream;
+            boolean endOfStream = false;
+
+            while (!this.closed && !endOfStream) {
+                byte[] buffer = new byte[bufferSize];
+                int byteCount = 0;
+
+                while (!this.closed && byteCount < buffer.length) {
+                    int read = stream.read(buffer, byteCount, buffer.length - byteCount);
+                    if (read < 0) {
+                        endOfStream = true;
+                        break;
+                    }
+                    if (read == 0) {
+                        // InputStream implementations should not return zero for a non-empty request,
+                        // but handling it here prevents a busy loop around a broken network wrapper.
+                        int singleByte = stream.read();
+                        if (singleByte < 0) {
+                            endOfStream = true;
+                            break;
+                        }
+                        buffer[byteCount++] = (byte) singleByte;
+                    } else {
+                        byteCount += read;
+                    }
+                }
+
+                if (byteCount > 0) {
+                    byte[] data = byteCount == buffer.length ? buffer : Arrays.copyOf(buffer, byteCount);
+                    if (!this.appendBuffer(data)) {
+                        break;
+                    }
+                }
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (!this.closed) {
+                InterruptedIOException interrupted = new InterruptedIOException("Asynchronous stream reader was interrupted");
+                interrupted.initCause(e);
+                problem = interrupted;
+            }
+        } catch (IOException e) {
+            if (!this.closed) {
+                problem = e;
+            }
+        } catch (Throwable t) {
+            if (!this.closed) {
+                problem = new IOException("Failed to read asynchronous stream", t);
+            }
+        } finally {
+            this.sourceStream = null;
+            this.finishReading(problem);
+        }
+    }
+
+    /**
+     * Appends a data chunk to the internal queue, blocking if the queue
+     * has reached {@link #maxBuffers} capacity.  Signals {@link #notEmpty}
+     * to wake any consumer waiting for data, and completes
+     * {@link #initialWait} once enough chunks are buffered.
+     *
+     * @return {@code false} if the stream has been closed
+     */
+    private boolean appendBuffer(byte[] data) throws InterruptedException {
+        this.lock.lockInterruptibly();
+        try {
+            while (!this.closed && this.readBytes.size() >= this.maxBuffers) {
+                this.notFull.await();
+            }
+            if (this.closed) {
+                return false;
+            }
+
+            this.readBytes.addLast(data);
+            if (this.readBytes.size() >= this.initialBuffers) {
+                this.initialWait.complete(null);
+            }
+            this.notEmpty.signalAll();
+            return true;
         } finally {
             this.lock.unlock();
         }
     }
 
     /**
-     * @return <code>true</code> if EOF has been reached
+     * Marks the producer as finished (real EOF or error) and wakes all
+     * waiting threads.  If the producer failed during initial buffering
+     * the error is passed through {@link #initialWait} so the constructor
+     * can throw it.
+     *
+     * @param problem the I/O error, or {@code null} for a clean EOF
      */
-    private boolean nextBuffer() {
+    private void finishReading(IOException problem) {
+        this.lock.lock();
         try {
-            this.lock.lock();
-            this.pointer = 0;
-            if (!this.waitFuture.isDone() && this.readBytes.size() < this.maxBuffers) {
-                this.waitFuture.complete(null); // Unlock read thread after enough data is read
+            this.eof = true;
+            this.failure = problem;
+            if (!this.initialWait.isDone()) {
+                if (problem != null) {
+                    this.initialWait.completeExceptionally(problem);
+                } else {
+                    // A finite stream may legitimately contain fewer than initialBuffers chunks.
+                    this.initialWait.complete(null);
+                }
             }
-            if (this.readBytes.isEmpty()) {
-                this.currentData = null;
-                return true;
-            }
-            this.currentData = this.readBytes.remove(0);
-            return false;
+            this.notEmpty.signalAll();
+            this.notFull.signalAll();
         } finally {
             this.lock.unlock();
         }
     }
 
-    private void rethrowException() throws IOException {
-        if (this.readFuture.isCompletedExceptionally()) {
+    /**
+     * Selects the next buffered chunk. An empty queue is not EOF while the producer is still alive:
+     * readers wait for data, a real EOF, a failure, or close().
+     */
+    private boolean ensureBuffer() throws IOException {
+        if (!this.closed && this.currentData != null && this.pointer < this.currentData.length) {
+            return true;
+        }
+
+        try {
+            this.lock.lockInterruptibly();
             try {
-                this.readFuture.join();
-            } catch (CompletionException e) {
-                if (e.getCause() instanceof IOException) {
-                    throw (IOException) e.getCause();
-                } else {
-                    throw new IOException(e.getCause());
+                this.currentData = null;
+                this.pointer = 0;
+
+                while (!this.closed && this.readBytes.isEmpty() && !this.eof && this.failure == null) {
+                    this.notEmpty.await();
                 }
+
+                if (this.closed) {
+                    return false;
+                }
+                if (!this.readBytes.isEmpty()) {
+                    this.currentData = this.readBytes.removeFirst();
+                    this.notFull.signalAll();
+                    return true;
+                }
+                if (this.failure != null) {
+                    throw this.failure;
+                }
+                return false; // The producer reached true EOF and no buffered data remains.
+            } finally {
+                this.lock.unlock();
             }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            InterruptedIOException interrupted = new InterruptedIOException("Interrupted while waiting for streamed data");
+            interrupted.initCause(e);
+            throw interrupted;
         }
     }
 
     @Override
     public int read() throws IOException {
-        this.rethrowException();
-        if ((this.currentData == null || this.pointer >= this.currentData.length) && this.nextBuffer()) {
+        if (!this.ensureBuffer()) {
             return -1;
         }
         return this.currentData[this.pointer++] & 0xFF;
     }
 
+    /**
+     * Returns at most one internal chunk per call.  The old implementation
+     * used a while loop that copied every chunk to the same destination
+     * offset {@code off}, overwriting previously read bytes.  Returning a
+     * single chunk per call follows {@link InputStream}'s contract.
+     */
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        this.rethrowException();
-        if ((this.currentData == null || this.pointer >= this.currentData.length) && this.nextBuffer()) {
+        Objects.requireNonNull(b, "b");
+        if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (len == 0) {
+            return 0;
+        }
+        if (!this.ensureBuffer()) {
             return -1;
         }
 
-        int readCount = 0;
-        while (readCount < len) {
-            if ((this.currentData == null || this.pointer >= this.currentData.length) && this.nextBuffer()) {
-                return readCount;
-            }
-
-            int readSize = Math.min(this.currentData.length - this.pointer, len - readCount);
-            System.arraycopy(this.currentData, this.pointer, b, off, readSize);
-            readCount += readSize;
-            this.pointer += readSize;
-        }
-
-        return readCount;
+        int readSize = Math.min(this.currentData.length - this.pointer, len);
+        System.arraycopy(this.currentData, this.pointer, b, off, readSize);
+        this.pointer += readSize;
+        return readSize;
     }
 
     @Override
-    public long skip(long n) {
-        if ((this.currentData == null || this.pointer >= this.currentData.length) && this.nextBuffer()) {
+    public long skip(long n) throws IOException {
+        if (n <= 0 || !this.ensureBuffer()) {
             return 0;
         }
 
-        long result = 0;
-        while (result < n) {
-            if ((this.currentData == null || this.pointer >= this.currentData.length) && this.nextBuffer()) {
-                return result;
-            }
-
-            long readSize = Math.min(this.currentData.length - this.pointer, n - result);
-            result += readSize;
-            this.pointer += (int) readSize;
-        }
-
-        return result;
+        int skipped = (int) Math.min((long) (this.currentData.length - this.pointer), n);
+        this.pointer += skipped;
+        return skipped;
     }
 
+    /**
+     * Returns the total bytes available across the current chunk and all
+     * queued chunks, clamped to {@link Integer#MAX_VALUE}.
+     */
+    @Override
+    public int available() {
+        if (this.closed) {
+            return 0;
+        }
+
+        this.lock.lock();
+        try {
+            long available = this.currentData == null ? 0 : this.currentData.length - this.pointer;
+            for (byte[] data : this.readBytes) {
+                available += data.length;
+                if (available >= Integer.MAX_VALUE) {
+                    return Integer.MAX_VALUE;
+                }
+            }
+            return (int) available;
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
+    /**
+     * Closes the underlying source stream to unblock the producer thread
+     * (which may be stuck in a network read), wakes all waiting consumers,
+     * and cancels the reader future.  Does not block on producer exit.
+     */
     @Override
     public void close() throws IOException {
-        this.closed = true;
-        this.waitFuture.complete(null); // Force read thread to stop waiting
-        this.readFuture.join();
+        InputStream stream;
+        this.lock.lock();
+        try {
+            if (this.closed) {
+                return;
+            }
+            this.closed = true;
+            this.currentData = null;
+            this.pointer = 0;
+            this.readBytes.clear();
+            stream = this.sourceStream;
+            this.initialWait.complete(null);
+            this.notEmpty.signalAll();
+            this.notFull.signalAll();
+        } finally {
+            this.lock.unlock();
+        }
+
+        IOException closeFailure = null;
+        if (stream != null) {
+            try {
+                stream.close(); // Unblock a producer currently stuck in the network read.
+            } catch (IOException e) {
+                closeFailure = e;
+            }
+        }
+        this.readFuture.cancel(true); // Do not wait forever for a misbehaving source implementation.
+        if (closeFailure != null) {
+            throw closeFailure;
+        }
     }
 
     /**

--- a/src/main/java/gg/moonflower/etched/api/util/LiveAudioInputStream.java
+++ b/src/main/java/gg/moonflower/etched/api/util/LiveAudioInputStream.java
@@ -1,0 +1,25 @@
+package gg.moonflower.etched.api.util;
+
+import java.io.FilterInputStream;
+import java.io.InputStream;
+
+/**
+ * Marker wrapper for an unbounded live audio source.  Used by
+ * {@link gg.moonflower.etched.api.sound.AbstractOnlineSoundInstance} to
+ * detect live streams at the type level and skip {@code LoopingAudioStream}
+ * wrapping — an infinite live stream never reaches EOF, so looping is both
+ * unnecessary and harmful (it would attempt to rewind the same stream).
+ *
+ * Local files do not receive this wrapper and keep the
+ * original looping behaviour.
+ */
+public final class LiveAudioInputStream extends FilterInputStream {
+
+    /**
+     * @param input the underlying live audio source opened by
+     *              {@link gg.moonflower.etched.api.sound.source.AudioSource#openLiveConnection}
+     */
+    public LiveAudioInputStream(InputStream input) {
+        super(input);
+    }
+}

--- a/src/main/java/gg/moonflower/etched/api/util/Mp3InputStream.java
+++ b/src/main/java/gg/moonflower/etched/api/util/Mp3InputStream.java
@@ -9,7 +9,13 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
- * Dynamically converts mp3 data to raw audio as the stream is read.
+ * Dynamically converts mp3 data to raw PCM audio as the stream is read.
+ *
+ * Each call to {@link #fillBuffer()} reads one MP3 frame from the
+ * underlying bitstream, decodes it via JLayer, and copies only the
+ * actual decoded sample count ({@code SampleBuffer.getBufferLength()})
+ * into the internal PCM buffer — never the unused tail of the
+ * fixed-capacity JLayer backing array.
  *
  * @author Ocelot
  */
@@ -53,9 +59,19 @@ public class Mp3InputStream extends InputStream {
 
             SampleBuffer decoderOutput = (SampleBuffer) this.decoder.decodeFrame(header, this.stream);
             short[] data = decoderOutput.getBuffer();
-            this.buffer.asShortBuffer().put(data);
-            this.buffer.position(data.length * Short.BYTES);
+            int sampleCount = decoderOutput.getBufferLength();
+            if (sampleCount < 0 || sampleCount > data.length) {
+                throw new IOException("MP3 decoder returned an invalid sample count: " + sampleCount);
+            }
+
+            // SampleBuffer owns a fixed-capacity backing array. Only getBufferLength() samples
+            // belong to this decoded frame; copying the whole array doubles mono frames and
+            // inserts stale/zero samples between them.
+            this.buffer.asShortBuffer().put(data, 0, sampleCount);
+            this.buffer.position(sampleCount * Short.BYTES);
             this.buffer.flip();
+        } catch (IOException e) {
+            throw e;
         } catch (Throwable t) {
             throw new IOException(t);
         } finally {

--- a/src/main/java/gg/moonflower/etched/api/util/ReconnectingInputStream.java
+++ b/src/main/java/gg/moonflower/etched/api/util/ReconnectingInputStream.java
@@ -1,0 +1,208 @@
+package gg.moonflower.etched.api.util;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.util.Objects;
+
+/**
+ * Keeps a live source open by reconnecting when the server closes or resets
+ * the current HTTP connection. Before the first audio byte is received,
+ * failures are bounded so an invalid station does not hang loading forever.
+ */
+public final class ReconnectingInputStream extends InputStream {
+
+    private static final int MAX_STARTUP_FAILURES = 3;
+    private static final long INITIAL_RETRY_DELAY_MILLIS = 250L;
+    private static final long MAX_RETRY_DELAY_MILLIS = 5000L;
+
+    private final AsyncInputStream.InputStreamSupplier source;
+    private final Object stateLock;
+
+    private volatile boolean closed;
+    private InputStream current;
+    private boolean receivedData;
+    private int startupFailures;
+    private long retryDelayMillis;
+
+    public ReconnectingInputStream(AsyncInputStream.InputStreamSupplier source) {
+        this.source = Objects.requireNonNull(source, "source");
+        this.stateLock = new Object();
+        this.retryDelayMillis = INITIAL_RETRY_DELAY_MILLIS;
+    }
+
+    /**
+     * Opens a new connection via {@link #source} on first access and
+     * returns the cached instance for subsequent calls within the same
+     * connection lifecycle.  After a reconnect the cache is cleared and
+     * a new connection is opened on the next call.
+     */
+    private InputStream getCurrent() throws IOException {
+        synchronized (this.stateLock) {
+            if (this.closed) {
+                throw new IOException("Stream closed");
+            }
+            if (this.current != null) {
+                return this.current;
+            }
+        }
+
+        InputStream opened = Objects.requireNonNull(this.source.get(), "source returned null");
+        synchronized (this.stateLock) {
+            if (this.closed) {
+                opened.close();
+                throw new IOException("Stream closed");
+            }
+            if (this.current == null) {
+                this.current = opened;
+                return opened;
+            }
+        }
+
+        opened.close();
+        synchronized (this.stateLock) {
+            return this.current;
+        }
+    }
+
+    /**
+     * Records that at least one audio byte has been received from the
+     * current connection.  Resets startup failure counters and retry
+     * delay — the station URL is confirmed valid, so subsequent
+     * reconnects are not bounded.
+     */
+    private void markDataReceived() {
+        synchronized (this.stateLock) {
+            this.receivedData = true;
+            this.startupFailures = 0;
+            this.retryDelayMillis = INITIAL_RETRY_DELAY_MILLIS;
+        }
+    }
+
+    /**
+     * Closes the current connection, sleeps with exponential backoff
+     * (250ms → 500ms → … → 5s), then lets {@link #getCurrent} open
+     * a fresh connection on the next read attempt.
+     * Before the first audio byte has been received ({@link #receivedData}
+     * is {@code false}), a maximum of {@value #MAX_STARTUP_FAILURES}
+     * consecutive reconnect attempts are permitted — this prevents an
+     * invalid URL from retrying forever during loading.
+     */
+    private void reconnect(IOException cause) throws IOException {
+        InputStream stream;
+        long delay;
+        synchronized (this.stateLock) {
+            stream = this.current;
+            this.current = null;
+            if (this.closed) {
+                return;
+            }
+
+            if (!this.receivedData && ++this.startupFailures >= MAX_STARTUP_FAILURES) {
+                IOException failure = new IOException("Live audio source failed before playback started", cause);
+                if (stream != null) {
+                    try {
+                        stream.close();
+                    } catch (IOException closeError) {
+                        failure.addSuppressed(closeError);
+                    }
+                }
+                throw failure;
+            }
+
+            delay = this.retryDelayMillis;
+            this.retryDelayMillis = Math.min(MAX_RETRY_DELAY_MILLIS, this.retryDelayMillis * 2L);
+        }
+
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (IOException closeError) {
+                cause.addSuppressed(closeError);
+            }
+        }
+
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            InterruptedIOException interrupted = new InterruptedIOException("Interrupted while reconnecting live audio");
+            interrupted.initCause(e);
+            interrupted.addSuppressed(cause);
+            throw interrupted;
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        byte[] one = new byte[1];
+        int read = this.read(one, 0, 1);
+        return read < 0 ? -1 : one[0] & 0xFF;
+    }
+
+    /**
+     * Reads from the current connection, transparently reconnecting when
+     * the server closes or resets the HTTP stream.  Returns {@code -1}
+     * only when the stream is explicitly {@linkplain #close() closed}
+     * — an infinite live source never signals EOF on its own.
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return 0;
+        }
+
+        while (!this.closed) {
+            IOException disconnectCause;
+            try {
+                int read = this.getCurrent().read(b, off, len);
+                if (read > 0) {
+                    this.markDataReceived();
+                    return read;
+                }
+                if (read == 0) {
+                    Thread.onSpinWait();
+                    continue;
+                }
+                disconnectCause = new EOFException("Live audio server closed the connection");
+            } catch (IOException e) {
+                disconnectCause = e;
+            }
+
+            if (this.closed) {
+                return -1;
+            }
+            this.reconnect(disconnectCause);
+        }
+        return -1;
+    }
+
+    @Override
+    public int available() throws IOException {
+        synchronized (this.stateLock) {
+            return this.current == null ? 0 : this.current.available();
+        }
+    }
+
+    /**
+     * Marks the stream as closed and closes any open underlying
+     * connection.  Idempotent — subsequent calls are ignored.
+     */
+    @Override
+    public void close() throws IOException {
+        InputStream stream;
+        synchronized (this.stateLock) {
+            if (this.closed) {
+                return;
+            }
+            this.closed = true;
+            stream = this.current;
+            this.current = null;
+        }
+        if (stream != null) {
+            stream.close();
+        }
+    }
+}


### PR DESCRIPTION
## Fix: Internet radio stuttering

### Problem

Internet radio streams (SHOUTcast/Icecast MP3) stutter — short gaps of silence every few seconds, "as if the record is skipping." The same URL plays perfectly in a browser. Local MP3/OGG files, jukeboxes, and etched music discs are unaffected.

### Root causes (5 bugs)

**1. False EOF on temporary buffer underrun** (`AsyncInputStream`)

`nextBuffer()` returned `true` (EOF) when the internal buffer was temporarily empty while the download thread was still fetching more data. JLayer interpreted the `-1` as end-of-stream and stopped decoding. A fraction of a second later the buffer refilled, but the audio pipeline had already restarted — producing the characteristic "record skip" stutter.

**2. Byte corruption in bulk read** (`AsyncInputStream`)

`read(byte[], off, len)` used a `while` loop that called `System.arraycopy()` with the same destination offset `off` for every internal chunk. Byte chunk N silently overwrote chunks 1…N−1 in the caller's buffer. The method reported N bytes read but only the last chunk survived — causing audible artifacts and making JLayer lose MP3 frame sync.

**3. Producer busy-loop on stream EOF** (`AsyncInputStream`)

When the source stream returned `−1` (server paused transmission), the inner read-loop exited but the outer `while (!closed)` continued indefinitely with zero-byte reads. Consumed CPU, buffer never refilled.

**4. `close()` hangs on station switch** (`AsyncInputStream`)

`close()` called `readFuture.join()`, blocking until the download thread exited. The download thread was stuck in `stream.read()` (blocking network I/O), so `close()` never returned. Switching stations leaked the old download thread.

**5. Tail garbage between MP3 frames** (`Mp3InputStream`)

`SampleBuffer.getBuffer()` returns a fixed-size backing array (2304 elements). The old code copied the entire array into the PCM buffer. For mono MP3 only ~1152 samples are valid per frame — the rest is stale/zero data from the previous frame, producing between-frame glitches.

### Solution

**`AsyncInputStream` — bounded producer-consumer rewrite**

Bounded queue with `ReentrantLock` + `Condition` (`notEmpty`/`notFull`). Consumer blocks on an empty queue until the producer delivers data or reaches real EOF — never sees a false EOF from a temporary buffer underrun. One internal chunk per `read(byte[],off,len)` call (no overwrite). `readLoop()` exits cleanly on EOF (no busy-loop). `close()` closes the underlying source stream first to unblock a producer stuck in network I/O, then cancels the reader future (no blocking `join()`).

**`ReconnectingInputStream`** (new)

SHOUTcast/Icecast servers routinely drop HTTP connections (load balancing, rotation). This class transparently reconnects: closes the dead stream, sleeps with exponential backoff (250ms → 500ms → 1s → 2s → 4s → 5s), opens a fresh connection. Before the first audio byte arrives, failures are bounded (3 attempts) to prevent an invalid URL from retrying forever.

**`AudioSource.java`**

- `openLiveConnection(url, headers)`: dedicated live-streaming connection that sets `Accept-Encoding: identity` to prevent servers from gzip-compressing the MP3 byte stream. Returns a `FilterInputStream` whose `close()` also disconnects the `HttpURLConnection`.
- `downloadTo()`: the first connection is now used only for URL classification (status code, headers) and is disconnected in a `finally` block. Live streams use a **separate** connection via `openLiveConnection()`, wrapped in `ReconnectingInputStream` → `AsyncInputStream` → `LiveAudioInputStream`. Headers are captured with `Map.copyOf()` for thread-safety before the lambda runs on a background thread.

**`LiveAudioInputStream`** (new)

Type-level marker (`FilterInputStream` subclass). Allows the audio pipeline to distinguish unbounded live sources from finite files via `instanceof` — no heuristics.

**`AbstractOnlineSoundInstance.java`**

Live streams skip LoopingAudioStream wrapping — they never reach EOF, so looping is unnecessary and harmful. Local files retain original looping behaviour.

**`Mp3InputStream.java`**

Copies getBufferLength() samples (actual decoded count) rather than the full getBuffer() backing array. Includes bounds check on the sample count.